### PR TITLE
Add additional sad path testing

### DIFF
--- a/app/controllers/api/v1/trips_controller.rb
+++ b/app/controllers/api/v1/trips_controller.rb
@@ -1,8 +1,12 @@
 class Api::V1::TripsController < ApplicationController
   def show
-    trip_data = TripFacade.get_trip_route(params[:origin], params[:destination])
-    coords = MapFacade.get_lat_long(params[:destination])
-    eta_weather = WeatherFacade.eta_weather(trip_data.travel_hours, coords.latitude, coords.longitude)
-    render json: TripSerializer.road_trip_json(trip_data, eta_weather)
+    if params[:api_key].length == 32
+      trip_data = TripFacade.get_trip_route(params[:origin], params[:destination])
+      coords = MapFacade.get_lat_long(params[:destination])
+      eta_weather = WeatherFacade.eta_weather(trip_data.travel_hours, coords.latitude, coords.longitude)
+      render json: TripSerializer.road_trip_json(trip_data, eta_weather)
+    else
+      render :json => { errors: "You Must Provide an API key" }, status: 401
+    end
   end
 end

--- a/app/controllers/api/v1/trips_controller.rb
+++ b/app/controllers/api/v1/trips_controller.rb
@@ -2,9 +2,13 @@ class Api::V1::TripsController < ApplicationController
   def create
     if check_api_key
       trip_data = TripFacade.get_trip_route(params[:origin], params[:destination])
-      coords = MapFacade.get_lat_long(params[:destination])
-      eta_weather = WeatherFacade.eta_weather(trip_data.travel_hours, coords.latitude, coords.longitude)
-      render json: TripSerializer.road_trip_json(trip_data, eta_weather)
+      if trip_data.travel_hours != "Impossible"
+        coords = MapFacade.get_lat_long(params[:destination])
+        eta_weather = WeatherFacade.eta_weather(trip_data.travel_hours, coords.latitude, coords.longitude)
+        render json: TripSerializer.road_trip_json(trip_data, eta_weather)
+      else 
+        render json: NoRouteSerializer.no_route_json(trip_data)
+      end
     else
       render :json => { errors: "You Must Provide a valid API key" }, status: 401
     end

--- a/app/controllers/api/v1/trips_controller.rb
+++ b/app/controllers/api/v1/trips_controller.rb
@@ -1,12 +1,20 @@
 class Api::V1::TripsController < ApplicationController
-  def show
-    if params[:api_key].length == 32
+  def create
+    if check_api_key
       trip_data = TripFacade.get_trip_route(params[:origin], params[:destination])
       coords = MapFacade.get_lat_long(params[:destination])
       eta_weather = WeatherFacade.eta_weather(trip_data.travel_hours, coords.latitude, coords.longitude)
       render json: TripSerializer.road_trip_json(trip_data, eta_weather)
     else
       render :json => { errors: "You Must Provide a valid API key" }, status: 401
+    end
+  end
+
+  private
+
+  def check_api_key
+    if params[:api_key].length == 32
+      user = User.find_by(api_key: params[:api_key])
     end
   end
 end

--- a/app/controllers/api/v1/trips_controller.rb
+++ b/app/controllers/api/v1/trips_controller.rb
@@ -6,7 +6,7 @@ class Api::V1::TripsController < ApplicationController
       eta_weather = WeatherFacade.eta_weather(trip_data.travel_hours, coords.latitude, coords.longitude)
       render json: TripSerializer.road_trip_json(trip_data, eta_weather)
     else
-      render :json => { errors: "You Must Provide an API key" }, status: 401
+      render :json => { errors: "You Must Provide a valid API key" }, status: 401
     end
   end
 end

--- a/app/poros/trip.rb
+++ b/app/poros/trip.rb
@@ -4,7 +4,17 @@ class Trip
   def initialize(trip_data, origin, destination)
     @start_city = origin
     @end_city = destination
-    @travel_time = Time.at(trip_data[:realTime]).utc.strftime("%H hours, %M minutes")
-    @travel_hours = Time.at(trip_data[:realTime]).utc.strftime("%H").to_i
+    @travel_time = route_available(trip_data)
+    @travel_hours = route_available(trip_data)
+  end
+
+  def route_available(trip_data)
+    if trip_data.has_key?(:routeError)
+      @travel_time = "Impossible"
+      @travel_hours = "Impossible"
+    else
+      @travel_time = Time.at(trip_data[:realTime]).utc.strftime("%H hours, %M minutes")
+      @travel_hours = Time.at(trip_data[:realTime]).utc.strftime("%H").to_i
+    end
   end
 end

--- a/app/poros/trip.rb
+++ b/app/poros/trip.rb
@@ -9,7 +9,7 @@ class Trip
   end
 
   def route_available(trip_data)
-    if trip_data.has_key?(:routeError)
+    if trip_data[:routeError][:errorCode] == 2
       @travel_time = "Impossible"
       @travel_hours = "Impossible"
     else

--- a/app/serializers/no_route_serializer.rb
+++ b/app/serializers/no_route_serializer.rb
@@ -1,0 +1,17 @@
+class NoRouteSerializer
+  def self.no_route_json(trip_data)
+    {
+      "data": {
+        "id": nil,
+        "type": "roadtrip",
+        "attributes": {
+          "start_city": trip_data.start_city,
+          "end_city": trip_data.end_city,
+          "travel_time": trip_data.travel_time,
+          "weather_at_eta": {
+          }
+        }
+      }
+    }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
 
       post '/sessions', to: 'sessions#create'
 
-      post '/road_trip', to: 'trips#show'
+      post '/road_trip', to: 'trips#create'
     end
   end
 end

--- a/spec/facades/trip_facade_spec.rb
+++ b/spec/facades/trip_facade_spec.rb
@@ -17,4 +17,15 @@ RSpec.describe TripFacade do
     expect(trip.end_city).to eq("Milwaukee, WI")
     expect(trip.travel_time).to be_a(String)
   end
+
+  it 'sends trip data for an impossible trip to the Trip poro' do
+    swiss_trip_json_response = File.read('spec/fixtures/swiss_trip_data.json')
+    stub_request(:get, "http://www.mapquestapi.com/directions/v2/route?from=Denver,%20CO&key=UHerve0fkvZVNWgBwQzNhk9nhiz3gtWX&to=Zurich,%20Switzerland").
+    to_return(status: 200, body: swiss_trip_json_response, headers: {})
+
+    origin = "Denver, CO"
+    destination = "Zurich, Switzerland"
+
+    expect(TripFacade.get_trip_route(origin, destination)).to be_a(Trip)
+  end
 end

--- a/spec/fixtures/swiss_trip_data.json
+++ b/spec/fixtures/swiss_trip_data.json
@@ -1,0 +1,19 @@
+{
+    "route": {
+        "routeError": {
+            "errorCode": 2,
+            "message": ""
+        }
+    },
+    "info": {
+        "statuscode": 402,
+        "copyright": {
+            "imageAltText": "© 2022 MapQuest, Inc.",
+            "imageUrl": "http://api.mqcdn.com/res/mqlogo.gif",
+            "text": "© 2022 MapQuest, Inc."
+        },
+        "messages": [
+            "We are unable to route with the given locations."
+        ]
+    }
+}

--- a/spec/poros/trip_spec.rb
+++ b/spec/poros/trip_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe Trip do
 
       trip_data = {
          :distance=>1047.017,
-         :realTime=>54577
+         :realTime=>54577,
+         :routeError=>{:errorCode=> -400, :message=>""}
                }
       trip = Trip.new(trip_data, origin, destination)
 

--- a/spec/poros/trip_spec.rb
+++ b/spec/poros/trip_spec.rb
@@ -29,6 +29,6 @@ RSpec.describe Trip do
     expect(trip.start_city).to eq("Denver, CO")
     expect(trip.end_city).to eq("Zurich, Switzerland")
     expect(trip.travel_time).to eq("Impossible")
-    expect(trip.travel_hours).to eq(nil)
+    expect(trip.travel_hours).to eq("Impossible")
   end
 end

--- a/spec/poros/trip_spec.rb
+++ b/spec/poros/trip_spec.rb
@@ -17,4 +17,18 @@ RSpec.describe Trip do
       expect(trip.travel_time).to eq("15 hours, 09 minutes")
       expect(trip.travel_hours).to eq(15)
   end
+
+  it 'has different attributes for an impossible trip' do
+    origin = "Denver, CO"
+    destination = "Zurich, Switzerland"
+
+    trip_data = {:routeError=>{:errorCode=>2, :message=>""}}
+
+    trip = Trip.new(trip_data, origin, destination)
+    expect(trip).to be_an_instance_of(Trip)
+    expect(trip.start_city).to eq("Denver, CO")
+    expect(trip.end_city).to eq("Zurich, Switzerland")
+    expect(trip.travel_time).to eq("Impossible")
+    expect(trip.travel_hours).to eq(nil)
+  end
 end

--- a/spec/requests/api/v1/trip_request_spec.rb
+++ b/spec/requests/api/v1/trip_request_spec.rb
@@ -121,7 +121,11 @@ RSpec.describe 'User Roadtrip' do
     expect(parsed_response[:errors]).to eq("You Must Provide a valid API key")
   end
 
-  xit 'does not return a weather block for impossible route and returns impossible for travel time' do
+  it 'returns an empty weather block for impossible route and returns impossible for travel time' do
+    swiss_trip_json_response = File.read('spec/fixtures/swiss_trip_data.json')
+    stub_request(:get, "http://www.mapquestapi.com/directions/v2/route?from=Denver,%20CO&key=UHerve0fkvZVNWgBwQzNhk9nhiz3gtWX&to=Zurich,%20Switzerland").
+    to_return(status: 200, body: swiss_trip_json_response, headers: {})
+
     user =
     {
       "email": "kerri@example.com",
@@ -152,5 +156,35 @@ RSpec.describe 'User Roadtrip' do
     parsed_trip_data = JSON.parse(response.body, symbolize_names: true)
 
     expect(response).to be_successful
+
+    expect(parsed_trip_data).to be_a(Hash)
+    expect(parsed_trip_data.length).to eq(1)
+    expect(parsed_trip_data).to have_key(:data)
+    expect(parsed_trip_data[:data]).to be_a(Hash)
+    expect(parsed_trip_data[:data].length).to eq(3)
+    expect(parsed_trip_data[:data]).to have_key(:id)
+    expect(parsed_trip_data[:data][:id]).to eq(nil)
+    expect(parsed_trip_data[:data]).to have_key(:type)
+    expect(parsed_trip_data[:data][:type]).to eq("roadtrip")
+    expect(parsed_trip_data[:data]).to have_key(:attributes)
+    expect(parsed_trip_data[:data][:attributes]).to be_a(Hash)
+    expect(parsed_trip_data[:data][:attributes].length).to eq(4)
+    expect(parsed_trip_data[:data][:attributes]).to have_key(:start_city)
+    expect(parsed_trip_data[:data][:attributes][:start_city]).to be_a(String)
+    expect(parsed_trip_data[:data][:attributes][:start_city]).to eq("Denver, CO")
+    expect(parsed_trip_data[:data][:attributes]).to have_key(:end_city)
+    expect(parsed_trip_data[:data][:attributes][:end_city]).to be_a(String)
+    expect(parsed_trip_data[:data][:attributes][:end_city]).to eq("Zurich, Switzerland")
+    expect(parsed_trip_data[:data][:attributes]).to have_key(:travel_time)
+    expect(parsed_trip_data[:data][:attributes][:travel_time]).to eq("Impossible")
+    expect(parsed_trip_data[:data][:attributes]).to have_key(:weather_at_eta)
+    expect(parsed_trip_data[:data][:attributes][:weather_at_eta]).to be_a(String)
+    expect(parsed_trip_data[:data][:attributes][:weather_at_eta]).to eq("")
+
+    # expect(parsed_trip_data[:data][:attributes][:weather_at_eta]).to be_a(Hash)
+    # expect(parsed_trip_data[:data][:attributes][:weather_at_eta]).to have_key(:temperature)
+    # expect(parsed_trip_data[:data][:attributes][:weather_at_eta][:temperature]).to be_a(Float)
+    # expect(parsed_trip_data[:data][:attributes][:weather_at_eta]).to have_key(:conditions)
+    # expect(parsed_trip_data[:data][:attributes][:weather_at_eta][:conditions]).to be_a(String)
   end
 end

--- a/spec/requests/api/v1/trip_request_spec.rb
+++ b/spec/requests/api/v1/trip_request_spec.rb
@@ -14,8 +14,6 @@ RSpec.describe 'User Roadtrip' do
     stub_request(:get, "https://api.openweathermap.org/data/2.5/onecall?appid=b223e219a2cff0890dbe4fae9e6d5836&exclude=minutely,alerts&lat=43.041072&lon=-87.909421&units=imperial").
     to_return(status: 200, body: eta_weather_json_response, headers: {})
 
-
-
     user =
     {
       "email": "kerri@example.com",
@@ -73,5 +71,86 @@ RSpec.describe 'User Roadtrip' do
     expect(parsed_trip_data[:data][:attributes][:weather_at_eta][:temperature]).to be_a(Float)
     expect(parsed_trip_data[:data][:attributes][:weather_at_eta]).to have_key(:conditions)
     expect(parsed_trip_data[:data][:attributes][:weather_at_eta][:conditions]).to be_a(String)
+  end
+
+  it 'requires an API key is provided in the request, otherwise returns a 401 error code' do
+    trip_json_response = File.read('spec/fixtures/trip_route_data.json')
+    stub_request(:get, "http://www.mapquestapi.com/directions/v2/route?from=Denver,%20CO&key=UHerve0fkvZVNWgBwQzNhk9nhiz3gtWX&to=Milwaukee,%20WI").
+    to_return(status: 200, body: trip_json_response, headers: {})
+
+    coords_json_response = File.read('spec/fixtures/coords_destination_data.json')
+    stub_request(:get, "http://www.mapquestapi.com/geocoding/v1/address?key=UHerve0fkvZVNWgBwQzNhk9nhiz3gtWX&location=Milwaukee,%20WI").
+    to_return(status: 200, body: coords_json_response, headers: {})
+
+    eta_weather_json_response = File.read('spec/fixtures/eta_weather_data.json')
+    stub_request(:get, "https://api.openweathermap.org/data/2.5/onecall?appid=b223e219a2cff0890dbe4fae9e6d5836&exclude=minutely,alerts&lat=43.041072&lon=-87.909421&units=imperial").
+    to_return(status: 200, body: eta_weather_json_response, headers: {})
+
+    user =
+    {
+      "email": "kerri@example.com",
+      "password": "password123",
+      "password_confirmation": "password123"
+    }
+    post "/api/v1/users", params: user, as: :json
+
+    login_params =
+        {
+          "email": "kerri@example.com",
+          "password": "password123"
+        }
+
+    post "/api/v1/sessions", params: login_params, as: :json
+
+    user = User.find_by(email: login_params[:email])
+
+    trip_params =
+        {
+          "origin": "Denver, CO",
+          "destination": "Milwaukee, WI",
+          "api_key": ""
+        }
+
+    post "/api/v1/road_trip", params: trip_params, as: :json
+
+    parsed_response = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).to_not be_successful
+
+    expect(response.status).to eq(401)
+    expect(parsed_response[:errors]).to eq("You Must Provide an API key")
+  end
+
+  xit 'does not return a weather block for impossible route and returns impossible for travel time' do
+    user =
+    {
+      "email": "kerri@example.com",
+      "password": "password123",
+      "password_confirmation": "password123"
+    }
+    post "/api/v1/users", params: user, as: :json
+
+    login_params =
+        {
+          "email": "kerri@example.com",
+          "password": "password123"
+        }
+
+    post "/api/v1/sessions", params: login_params, as: :json
+
+    user = User.find_by(email: login_params[:email])
+
+    trip_params =
+        {
+          "origin": "Denver, CO",
+          "destination": "Zurich, Switzerland",
+          "api_key": "#{user.api_key}"
+        }
+
+    post "/api/v1/road_trip", params: trip_params, as: :json
+
+    parsed_trip_data = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).to be_successful
   end
 end

--- a/spec/requests/api/v1/trip_request_spec.rb
+++ b/spec/requests/api/v1/trip_request_spec.rb
@@ -180,11 +180,5 @@ RSpec.describe 'User Roadtrip' do
     expect(parsed_trip_data[:data][:attributes]).to have_key(:weather_at_eta)
     expect(parsed_trip_data[:data][:attributes][:weather_at_eta]).to be_a(Hash)
     expect(parsed_trip_data[:data][:attributes][:weather_at_eta]).to eq({})
-
-    # expect(parsed_trip_data[:data][:attributes][:weather_at_eta]).to be_a(Hash)
-    # expect(parsed_trip_data[:data][:attributes][:weather_at_eta]).to have_key(:temperature)
-    # expect(parsed_trip_data[:data][:attributes][:weather_at_eta][:temperature]).to be_a(Float)
-    # expect(parsed_trip_data[:data][:attributes][:weather_at_eta]).to have_key(:conditions)
-    # expect(parsed_trip_data[:data][:attributes][:weather_at_eta][:conditions]).to be_a(String)
   end
 end

--- a/spec/requests/api/v1/trip_request_spec.rb
+++ b/spec/requests/api/v1/trip_request_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe 'User Roadtrip' do
     expect(response).to_not be_successful
 
     expect(response.status).to eq(401)
-    expect(parsed_response[:errors]).to eq("You Must Provide an API key")
+    expect(parsed_response[:errors]).to eq("You Must Provide a valid API key")
   end
 
   xit 'does not return a weather block for impossible route and returns impossible for travel time' do

--- a/spec/requests/api/v1/trip_request_spec.rb
+++ b/spec/requests/api/v1/trip_request_spec.rb
@@ -178,8 +178,8 @@ RSpec.describe 'User Roadtrip' do
     expect(parsed_trip_data[:data][:attributes]).to have_key(:travel_time)
     expect(parsed_trip_data[:data][:attributes][:travel_time]).to eq("Impossible")
     expect(parsed_trip_data[:data][:attributes]).to have_key(:weather_at_eta)
-    expect(parsed_trip_data[:data][:attributes][:weather_at_eta]).to be_a(String)
-    expect(parsed_trip_data[:data][:attributes][:weather_at_eta]).to eq("")
+    expect(parsed_trip_data[:data][:attributes][:weather_at_eta]).to be_a(Hash)
+    expect(parsed_trip_data[:data][:attributes][:weather_at_eta]).to eq({})
 
     # expect(parsed_trip_data[:data][:attributes][:weather_at_eta]).to be_a(Hash)
     # expect(parsed_trip_data[:data][:attributes][:weather_at_eta]).to have_key(:temperature)

--- a/spec/requests/api/v1/trip_request_spec.rb
+++ b/spec/requests/api/v1/trip_request_spec.rb
@@ -77,15 +77,7 @@ RSpec.describe 'User Roadtrip' do
     trip_json_response = File.read('spec/fixtures/trip_route_data.json')
     stub_request(:get, "http://www.mapquestapi.com/directions/v2/route?from=Denver,%20CO&key=UHerve0fkvZVNWgBwQzNhk9nhiz3gtWX&to=Milwaukee,%20WI").
     to_return(status: 200, body: trip_json_response, headers: {})
-
-    coords_json_response = File.read('spec/fixtures/coords_destination_data.json')
-    stub_request(:get, "http://www.mapquestapi.com/geocoding/v1/address?key=UHerve0fkvZVNWgBwQzNhk9nhiz3gtWX&location=Milwaukee,%20WI").
-    to_return(status: 200, body: coords_json_response, headers: {})
-
-    eta_weather_json_response = File.read('spec/fixtures/eta_weather_data.json')
-    stub_request(:get, "https://api.openweathermap.org/data/2.5/onecall?appid=b223e219a2cff0890dbe4fae9e6d5836&exclude=minutely,alerts&lat=43.041072&lon=-87.909421&units=imperial").
-    to_return(status: 200, body: eta_weather_json_response, headers: {})
-
+    
     user =
     {
       "email": "kerri@example.com",

--- a/spec/requests/api/v1/user_request_spec.rb
+++ b/spec/requests/api/v1/user_request_spec.rb
@@ -82,4 +82,40 @@ RSpec.describe "Requests for User" do
     expect(response.status).to eq(400)
     expect(parsed_response[:errors][0]).to eq("Email has already been taken")
   end
+
+  it 'returns an error if email is blank' do
+    user =
+    {
+      "email": "",
+      "password": "password123",
+      "password_confirmation": "password456"
+    }
+
+    post "/api/v1/users", params: user, as: :json
+
+    parsed_response = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).to_not be_successful
+
+    expect(response.status).to eq(400)
+    expect(parsed_response[:errors][0]).to eq("Email can't be blank")
+  end
+
+  it 'returns an error if password is blank' do
+    user =
+    {
+      "email": "cat@gmail.com",
+      "password": "",
+      "password_confirmation": ""
+    }
+
+    post "/api/v1/users", params: user, as: :json
+
+    parsed_response = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).to_not be_successful
+
+    expect(response.status).to eq(400)
+    expect(parsed_response[:errors][0]).to eq("Password can't be blank")
+  end
 end

--- a/spec/services/map_service_spec.rb
+++ b/spec/services/map_service_spec.rb
@@ -39,4 +39,22 @@ RSpec.describe MapService do
     expect(MapService.get_trip_route(origin, destination)[:route]).to have_key(:realTime)
     expect(MapService.get_trip_route(origin, destination)[:route][:realTime]).to be_an(Integer)
   end
+
+  it 'profides data if a trip route is impossible' do
+    swiss_trip_json_response = File.read('spec/fixtures/swiss_trip_data.json')
+    stub_request(:get, "http://www.mapquestapi.com/directions/v2/route?from=Denver,%20CO&key=UHerve0fkvZVNWgBwQzNhk9nhiz3gtWX&to=Zurich,%20Switzerland").
+    to_return(status: 200, body: swiss_trip_json_response, headers: {})
+
+    origin = "Denver, CO"
+    destination = "Zurich, Switzerland"
+
+    expect(MapService.get_trip_route(origin, destination)).to be_a(Hash)
+    expect(MapService.get_trip_route(origin, destination)).to have_key(:route)
+    expect(MapService.get_trip_route(origin, destination)[:route]).to be_a(Hash)
+    expect(MapService.get_trip_route(origin, destination)[:route]).to have_key(:routeError)
+    expect(MapService.get_trip_route(origin, destination)).to have_key(:info)
+    expect(MapService.get_trip_route(origin, destination)[:info]).to be_a(Hash)
+    expect(MapService.get_trip_route(origin, destination)[:info][:messages]).to be_an(Array)
+    expect(MapService.get_trip_route(origin, destination)[:info][:messages][0]).to eq("We are unable to route with the given locations.")
+  end
 end


### PR DESCRIPTION
Add sad path if API key incorrect or not provided when post request made for road trip.
Add different json response if a road trip is not possible.